### PR TITLE
#19 日記記録数の取得と表示

### DIFF
--- a/lib/diary/diary_controller.dart
+++ b/lib/diary/diary_controller.dart
@@ -29,7 +29,7 @@ final diaryRefProvider = Provider((ref) {
   return diaryRef;
 });
 
-final diaryStreamProvider = StreamProvider<List<Diary>>((ref) {
+final diaryStreamProvider = StreamProvider.autoDispose<List<Diary>>((ref) {
   final repo = ref.watch(diaryRepoProvider);
   final selectedMonthDate = ref.watch(selectedMonthDateProvider);
   final diaryList =
@@ -37,9 +37,10 @@ final diaryStreamProvider = StreamProvider<List<Diary>>((ref) {
   return diaryList;
 });
 
-final diaryCountProvider = FutureProvider<int>((ref) async {
+final diaryCountProvider = FutureProvider.autoDispose<int>((ref) async {
   final repo = ref.watch(diaryRepoProvider);
   final count = await repo.getDiaryCount();
+  print('count = $count');
   return count;
 });
 

--- a/lib/diary/diary_controller.dart
+++ b/lib/diary/diary_controller.dart
@@ -37,11 +37,10 @@ final diaryStreamProvider = StreamProvider.autoDispose<List<Diary>>((ref) {
   return diaryList;
 });
 
-final diaryCountProvider = FutureProvider.autoDispose<int>((ref) async {
+final diaryCountProvider = FutureProvider.autoDispose<String?>((ref) async {
   final repo = ref.watch(diaryRepoProvider);
   final count = await repo.getDiaryCount();
-  print('count = $count');
-  return count;
+  return count.toString();
 });
 
 final diaryControllerProvider = Provider((ref) => DiaryController(ref: ref));

--- a/lib/diary/diary_controller.dart
+++ b/lib/diary/diary_controller.dart
@@ -37,6 +37,12 @@ final diaryStreamProvider = StreamProvider<List<Diary>>((ref) {
   return diaryList;
 });
 
+final diaryCountProvider = FutureProvider<int>((ref) async {
+  final repo = ref.watch(diaryRepoProvider);
+  final count = await repo.getDiaryCount();
+  return count;
+});
+
 final diaryControllerProvider = Provider((ref) => DiaryController(ref: ref));
 
 class DiaryController {

--- a/lib/diary/diary_repository.dart
+++ b/lib/diary/diary_repository.dart
@@ -54,4 +54,11 @@ class DiaryRepository {
   Future<void> deleteDiary({required Diary diary}) async {
     await diaryRef.doc(diary.id).delete();
   }
+
+  // DiaryCollectionのドキュメント数を取得する
+  Future<int> getDiaryCount() async {
+    final query = diaryRef.count();
+    final snap = await query.get();
+    return snap.count;
+  }
 }

--- a/lib/diary/diary_repository.dart
+++ b/lib/diary/diary_repository.dart
@@ -59,6 +59,7 @@ class DiaryRepository {
   Future<int> getDiaryCount() async {
     final query = diaryRef.count();
     final snap = await query.get();
+    print(snap.count);
     return snap.count;
   }
 }

--- a/lib/diary/diary_repository.dart
+++ b/lib/diary/diary_repository.dart
@@ -56,10 +56,9 @@ class DiaryRepository {
   }
 
   // DiaryCollectionのドキュメント数を取得する
-  Future<int> getDiaryCount() async {
+  Future<int?> getDiaryCount() async {
     final query = diaryRef.count();
     final snap = await query.get();
-    print(snap.count);
     return snap.count;
   }
 }

--- a/lib/diary/input_diary_dialog.dart
+++ b/lib/diary/input_diary_dialog.dart
@@ -129,7 +129,30 @@ class _InputDiaryDialogState extends ConsumerState<InputDiaryDialog> {
     AwesomeDialog(
       context: context,
       dialogType: DialogType.success,
-      title: '登録完了！',
+      body: Column(
+        children: [
+          Column(
+            children: [
+              Text(
+                '登録完了！',
+                style: TextStyle(fontSize: 16.sp),
+              ),
+              const SizedBox(
+                height: 8,
+              ),
+              HookConsumer(
+                builder: (context, ref, child) {
+                  final diaryCount = ref.watch(diaryCountProvider).value ?? 0;
+                  return Text(
+                    '$diaryCount個目の記録です',
+                    style: TextStyle(fontSize: 14.sp),
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
       btnOkText: '閉じる',
       btnOkOnPress: () {
         Navigator.pop(context);

--- a/lib/diary/input_diary_dialog.dart
+++ b/lib/diary/input_diary_dialog.dart
@@ -142,9 +142,9 @@ class _InputDiaryDialogState extends ConsumerState<InputDiaryDialog> {
               ),
               HookConsumer(
                 builder: (context, ref, child) {
-                  final diaryCount = ref.watch(diaryCountProvider).value ?? 0;
+                  final diaryCountStr = ref.watch(diaryCountProvider).value;
                   return Text(
-                    '$diaryCount個目の記録です',
+                    diaryCountStr != null ? '$diaryCountStr個目の記録です' : '',
                     style: TextStyle(fontSize: 14.sp),
                   );
                 },


### PR DESCRIPTION
## 関連issue
close #19 

## やったこと
- diaryListコレクションのドキュメント数をFirestoreのcountを使用して取得
- 日記登録時のダイアログで取得した日数を表示

## 関連画像
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-04-13 at 14 59 26](https://user-images.githubusercontent.com/58384546/231667290-2e0a5eb1-53c5-4e3d-9f1c-be5173245993.png)

