### PR TITLE
#67 16文字以上の場合エラーダイアログを表示する

### DIFF
--- a/lib/feature/diary/input_diary_dialog.dart
+++ b/lib/feature/diary/input_diary_dialog.dart
@@ -10,7 +10,6 @@ import '../../component/stadium_border_button.dart';
 import '../admob/ad_providers.dart';
 import '../date/date_controller.dart';
 import 'diary.dart';
-import 'diary_controller.dart';
 import 'diary_providers.dart';
 
 class InputDiaryDialog extends HookConsumerWidget {
@@ -67,6 +66,10 @@ class InputDiaryDialog extends HookConsumerWidget {
                   onPressed: () async {
                     if (diaryInputController.text.isEmpty) {
                       _showErrorDialog(context, '文字が入力されていません');
+                      return;
+                    }
+                    if(diaryInputController.text.length > 16) {
+                      _showErrorDialog(context, '16文字以内に修正してください');
                       return;
                     }
                     if (diary?.content == diaryInputController.text) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:limited_characters_diary/feature/local_notification/local_notification_controller.dart';
 import 'package:limited_characters_diary/feature/local_notification/local_notification_repository.dart';
 import 'package:limited_characters_diary/firebase_options_dev.dart' as dev;
 import 'package:limited_characters_diary/firebase_options_prod.dart' as prod;


### PR DESCRIPTION
## 関連issue
close #67

## やったこと
- 16文字以上の場合エラーダイアログを表示する
- iPhoneは16文字以上入力しても16文字以下に勝手に修正されていたが、Androidだと16文字以上もTextFieldに入力できてしまうようだったので修正

## 関連画像
<img src="" width=300>
