### PR TITLE
#89 fix pass code logic

### DIFF
--- a/lib/feature/local_notification/local_notification_providers.dart
+++ b/lib/feature/local_notification/local_notification_providers.dart
@@ -61,3 +61,11 @@ final isShowSetNotificationDialogOnLaunchProvider = Provider<bool>((ref) {
 
   return true;
 });
+
+/// 初めて通知設定したかどうかの管理
+///
+/// iOSの場合、初めて通知設定する際に端末の通知許可設定が表示される
+/// その際アプリがinactiveになるため、パスコードロック画面が表示されてしまう
+/// このinactive時にはパスコードロック画面を表示したくないため、初めて通知設定したかどうかをフラグ管理するもの
+/// isShowScreenLockProviderにて使用
+final isInitialSetNotificationProvider = StateProvider((ref) => false);

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -129,6 +129,11 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
     if (setTime == data) {
       return;
     }
+    //初めて通知設定する場合、trueに
+    //
+    if(data == null) {
+      ref.read(isInitialSetNotificationProvider.notifier).state = true;
+    }
     //通知設定
     await ref
         .read(localNotificationControllerProvider)

--- a/lib/feature/pass_code/pass_code_providers.dart
+++ b/lib/feature/pass_code/pass_code_providers.dart
@@ -1,4 +1,5 @@
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:limited_characters_diary/feature/local_notification/local_notification_providers.dart';
 import 'package:limited_characters_diary/feature/shared_preferences/shared_preferences_providers.dart';
 
 import '../admob/ad_providers.dart';
@@ -42,6 +43,12 @@ final isShowScreenLockProvider = Provider<bool>((ref) {
 
   // 全画面広告から復帰した際は表示しない
   if(ref.watch(isShownInterstitialAdProvider)) {
+    return false;
+  }
+
+  // 初めて通知設定した際は、端末の通知設定ダイアログによりinactiveになるが、その際は表示しない
+  // isShowScreenLockProviderにて使用
+  if(ref.watch(isInitialSetNotificationProvider)) {
     return false;
   }
 

--- a/lib/feature/pass_code/pass_code_providers.dart
+++ b/lib/feature/pass_code/pass_code_providers.dart
@@ -41,17 +41,6 @@ final isShowScreenLockProvider = Provider<bool>((ref) {
     return false;
   }
 
-  // 全画面広告から復帰した際は表示しない
-  if(ref.watch(isShownInterstitialAdProvider)) {
-    return false;
-  }
-
-  // 初めて通知設定した際は、端末の通知設定ダイアログによりinactiveになるが、その際は表示しない
-  // isShowScreenLockProviderにて使用
-  if(ref.watch(isInitialSetNotificationProvider)) {
-    return false;
-  }
-
   // 既にロック画面が開いていたら表示しない
   if (ref.watch(isOpenedScreenLockProvider)) {
     return false;

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -8,6 +8,7 @@ import 'package:limited_characters_diary/feature/diary/sized_list_tile.dart';
 import 'package:limited_characters_diary/feature/update_info/forced_update_dialog.dart';
 import 'package:limited_characters_diary/feature/update_info/under_repair_dialog.dart';
 import 'constant/constant.dart';
+import 'feature/admob/ad_providers.dart';
 import 'feature/date/date_controller.dart';
 import 'feature/diary/diary.dart';
 import 'feature/diary/diary_providers.dart';
@@ -33,6 +34,17 @@ class ListPage extends HookConsumerWidget {
       /// 最初はresumedのタイミングで呼び出そうとしたが、一瞬ListPageが表示されてしまうため、
       /// inactiveのタイミングで呼び出すこととしたもの
       if(current == AppLifecycleState.inactive) {
+        // 全画面広告から復帰した際は表示しない
+        if(ref.read(isShownInterstitialAdProvider)) {
+          return;
+        }
+
+        // 初めて通知設定した際は、端末の通知設定ダイアログによりinactiveになるが、その際は表示しない
+        // isShowScreenLockProviderにて使用
+        if(ref.read(isInitialSetNotificationProvider)) {
+          return;
+        }
+
         if(ref.read(isShowScreenLockProvider)) {
           await showScreenLock(context, ref);
         }

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -35,6 +35,7 @@ class ListPage extends HookConsumerWidget {
       /// inactiveのタイミングで呼び出すこととしたもの
       if(current == AppLifecycleState.inactive) {
         // 全画面広告から復帰した際は表示しない
+        // 全画面広告表示時にinactiveになるが、そのタイミングではパスコードロック画面を表示したくないため
         if(ref.read(isShownInterstitialAdProvider)) {
           return;
         }
@@ -44,6 +45,8 @@ class ListPage extends HookConsumerWidget {
         if(ref.read(isInitialSetNotificationProvider)) {
           return;
         }
+        // 上記の全画面広告と端末の通知設定によるinactive時は処理を除外するコードは、
+        // 当初「isShowScreenLockProvider」に記載していたが、inactive時にのみ必要な条件分岐のためこちらに記載
 
         if(ref.read(isShowScreenLockProvider)) {
           await showScreenLock(context, ref);


### PR DESCRIPTION
## 関連issue
close #89 

## やったこと
- 端末の通知許可ダイアログが表示される際にパスコード画面が表示されてしまうことへの対応
- 端末の通知許可ダイアログが表示されたことを判別するフラグを用意
- trueの場合にはパスコード画面を表示しないよう制御

## 関連画像
<img src="" width=300>
