### PR TITLE
#84 fix list page scroll controller

### DIFF
--- a/lib/constant/constant.dart
+++ b/lib/constant/constant.dart
@@ -38,4 +38,6 @@ class Constant {
   static const appStoreUrl = 'https://apps.apple.com/us/app/16%E6%96%87%E5%AD%97%E6%97%A5%E8%A8%98/id6448646374';
 
   static const playStoreUrl = 'https://play.google.com/store/apps/details?id=com.futtaro.limited_characters_diary';
+
+  static const sizedListTileHeight = 32.0;
 }

--- a/lib/feature/diary/sized_list_tile.dart
+++ b/lib/feature/diary/sized_list_tile.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:limited_characters_diary/constant/constant.dart';
 
-class SizedListTile extends StatelessWidget {
-  const SizedListTile({
+class SizedHeightListTile extends StatelessWidget {
+  const SizedHeightListTile({
     required this.onTap,
     this.onLongPress,
     this.tileColor,

--- a/lib/feature/diary/sized_list_tile.dart
+++ b/lib/feature/diary/sized_list_tile.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:limited_characters_diary/constant/constant.dart';
 
 class SizedListTile extends StatelessWidget {
   const SizedListTile({
     required this.onTap,
     this.onLongPress,
-    this.height,
     this.tileColor,
     required this.leading,
     required this.title,
@@ -12,7 +12,6 @@ class SizedListTile extends StatelessWidget {
   });
   final VoidCallback onTap;
   final VoidCallback? onLongPress;
-  final double? height;
   final Color? tileColor;
   final Widget leading;
   final Widget title;
@@ -24,7 +23,7 @@ class SizedListTile extends StatelessWidget {
       onLongPress: onLongPress,
       child: SizedBox(
         width: double.infinity,
-        height: height ?? 32,
+        height: Constant.sizedListTileHeight,
         child: ColoredBox(
           color: tileColor ?? Colors.transparent,
           child: Row(

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -92,7 +92,7 @@ class ListPage extends HookConsumerWidget {
         if(today.day <= 10) {
           return;
         }
-        scrollController.jumpTo((32.0 * (today.day - 5)));
+        scrollController.jumpTo(Constant.sizedListTileHeight * (today.day - 5));
       }
 
       /// 所定条件をクリアしている場合、起動時に日記入力ダイアログを自動表示する

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -259,7 +259,7 @@ class ListPage extends HookConsumerWidget {
                                   dateController.searchDayOfWeek(indexDate);
                               final dayStrColor =
                                   dateController.choiceDayStrColor(indexDate);
-                              return SizedListTile(
+                              return SizedHeightListTile(
                                 //本日はハイライト
                                 tileColor: dateController.isToday(indexDate)
                                     ? Constant.accentColor

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -27,6 +27,8 @@ class ListPage extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
 
+    final scrollController = useScrollController();
+
     useOnAppLifecycleStateChange((previous, current) async {
 
       /// バックグラウンドになったタイミングで、ScreenLockを呼び出す
@@ -75,6 +77,23 @@ class ListPage extends HookConsumerWidget {
     });
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+
+      /// 月の後半になると、初期起動画面で該当日が表示されないことへの対応
+      ///
+      /// 当月の場合のみ、「SizedListTileの高さ*（当日の日数-5）」分だけスクロールする
+      /// -5としているのは、当日を一番上にするよりも当日の4日前まで見れた方が良いと考えたため
+      /// ほとんどの端末で15日程度は表示できると考えるため、当日が10日以下の場合はスクロールしない
+      final today = ref.read(dateControllerProvider).today;
+      final selectedMonth = ref.read(dateControllerProvider).selectedMonth;
+      if(today.month == selectedMonth.month) {
+        if (!scrollController.hasClients) {
+          return;
+        }
+        if(today.day <= 10) {
+          return;
+        }
+        scrollController.jumpTo((32.0 * (today.day - 5)));
+      }
 
       /// 所定条件をクリアしている場合、起動時に日記入力ダイアログを自動表示する
       if(ref.read(isShowEditDialogOnLaunchProvider)) {
@@ -208,6 +227,7 @@ class ListPage extends HookConsumerWidget {
                         child: Padding(
                           padding: const EdgeInsets.only(top: 4, bottom: 8),
                           child: ListView.separated(
+                            controller: scrollController,
                             separatorBuilder: (BuildContext context, int index) {
                               return const Divider(
                                 height: 0.5,


### PR DESCRIPTION
## 関連issue
close #84 

## やったこと
- 月の後半になると、初期起動画面で該当日が表示されないことへの対応
- 当月の場合のみ、「SizedListTileの高さ*（当日の日数-5）」分だけスクロールする
- -5としているのは、当日を一番上にするよりも当日の4日前まで見れた方が良いと考えたため
- ほとんどの端末で15日程度は表示できると考えるため、当日が10日以下の場合はスクロールしない

## 関連画像
<img src="" width=300>
