### PR TITLE
#92 fix show input dialog logic

### DIFF
--- a/lib/feature/date/date_controller.dart
+++ b/lib/feature/date/date_controller.dart
@@ -89,6 +89,21 @@ class DateController {
     return indexDate.isAtSameMomentAs(today);
   }
 
+  bool isThisMonth() {
+    return selectedMonth.month == today.month;
+  }
+
+  // 今日-5日に自動で画面スクロールするかどうか
+  bool isJumpToAroundToday() {
+    if(!isThisMonth()) {
+      return false;
+    }
+    if(today.day <= 10) {
+      return false;
+    }
+    return true;
+  }
+
   //2029年までの日本の祝日 20230324時点
   //以下のデータを加工
   //https://github.com/holiday-jp/holiday_jp/blob/master/holidays.yml

--- a/lib/feature/diary/diary_providers.dart
+++ b/lib/feature/diary/diary_providers.dart
@@ -71,6 +71,13 @@ final isShowEditDialogOnLaunchProvider = Provider.autoDispose<bool>((ref) {
     return false;
   }
 
+  // 当月以外の月を表示した際は表示しない
+  final today = ref.watch(todayProvider);
+  final selectedMonth = ref.watch(selectedMonthDateProvider);
+  if(today.month != selectedMonth.month) {
+    return false;
+  }
+
   // 日記情報がnullの場合処理終了
   final diaryList = ref.watch(diaryStreamProvider).value;
   if(diaryList == null) {
@@ -78,7 +85,6 @@ final isShowEditDialogOnLaunchProvider = Provider.autoDispose<bool>((ref) {
   }
 
   // 既に当日の日記が入力済みの場合処理終了
-  final today = ref.watch(todayProvider);
   final filteredDiary = diaryList.where((element) => element.diaryDate == today).toList();
   if(filteredDiary.isNotEmpty) {
     return false;

--- a/lib/feature/diary/diary_providers.dart
+++ b/lib/feature/diary/diary_providers.dart
@@ -48,16 +48,8 @@ final diaryCountProvider = FutureProvider.autoDispose<int>((ref) async {
 
 final diaryControllerProvider = Provider((ref) => DiaryController(ref: ref));
 
-final isOpenedEditDialogProvider = StateProvider((ref) => false);
-
 /// 起動時に日記入力ダイアログを自動表示するかどうか
 final isShowEditDialogOnLaunchProvider = Provider.autoDispose<bool>((ref) {
-
-  // 既に日記表示ダイアログが表示されていたら処理終了
-  final isOpenedEditDialog = ref.watch(isOpenedEditDialogProvider);
-  if(isOpenedEditDialog) {
-    return false;
-  }
 
   // パスコード画面を表示している場合は処理終了
   final isScreenLocked = ref.watch(isOpenedScreenLockProvider);

--- a/lib/feature/local_notification/local_notification_providers.dart
+++ b/lib/feature/local_notification/local_notification_providers.dart
@@ -38,27 +38,14 @@ final localNotificationTimeFutureProvider =
   return notificationTime;
 });
 
-// 「WidgetsBinding.instance.addPostFrameCallback」は、
-// ビルドするたびに呼び出されダイアログが複数重なってしまうため、
-// 既にダイアログが開かれたかを判定するフラグを用意
-final isOpenedSetNotificationDialogOnLaunchProvider =
-    StateProvider<bool>((_) => false);
-
 /// アラーム設定を促すダイアログを自動表示させるかどうか
 ///
-/// 初回起動かつ、アラーム設定ダイアログが表示されていない場合には、自動表示する
+/// 初回起動の場合には、自動表示する
 final isShowSetNotificationDialogOnLaunchProvider = Provider<bool>((ref) {
   final isFirstLaunch = ref.watch(isFirstLaunchProvider);
   if (!isFirstLaunch) {
     return false;
   }
-
-  final isOpenedSetNotificationDialog =
-      ref.watch(isOpenedSetNotificationDialogOnLaunchProvider);
-  if (isOpenedSetNotificationDialog) {
-    return false;
-  }
-
   return true;
 });
 

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -43,6 +43,8 @@ class ListPage extends HookConsumerWidget {
         // 初めて通知設定した際は、端末の通知設定ダイアログによりinactiveになるが、その際は表示しない
         // isShowScreenLockProviderにて使用
         if (ref.read(isInitialSetNotificationProvider)) {
+          // falseに戻さないと、初めて通知設定した後にinactiveにした際にロック画面が表示されない
+          ref.read(isInitialSetNotificationProvider.notifier).state = false;
           return;
         }
         // 上記の全画面広告と端末の通知設定によるinactive時は処理を除外するコードは、

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -83,7 +83,7 @@ class ListPage extends HookConsumerWidget {
       /// 当月の場合のみ、「SizedListTileの高さ*（当日の日数-5）」分だけスクロールする
       /// -5としているのは、当日を一番上にするよりも当日の4日前まで見れた方が良いと考えたため
       /// ほとんどの端末で15日程度は表示できると考えるため、当日が10日以下の場合はスクロールしない
-      if(ref.read(dateControllerProvider).isJumpToToday()) {
+      if(ref.read(dateControllerProvider).isJumpToAroundToday()) {
         final today = ref.read(todayProvider);
         if (scrollController.hasClients) {
           scrollController.jumpTo(Constant.sizedListTileHeight * (today.day - 5));

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -107,7 +107,6 @@ class ListPage extends HookConsumerWidget {
 
           /// 所定条件をクリアしている場合、起動時に日記入力ダイアログを自動表示する
           if (ref.read(isShowEditDialogOnLaunchProvider)) {
-            ref.read(isOpenedEditDialogProvider.notifier).state = true;
             await _showEditDialog(context, null);
             return;
           }
@@ -117,9 +116,6 @@ class ListPage extends HookConsumerWidget {
           ///
           /// ユーザー動作の順番的にSetNotificationDialog→EditDialog→ListPageの順で表示したいため、以下のような記述とした
           if (ref.read(isShowSetNotificationDialogOnLaunchProvider)) {
-            ref
-                .read(isOpenedSetNotificationDialogOnLaunchProvider.notifier)
-                .state = true;
             await _showSetNotificationDialog(context);
             if (context.mounted) {
               await _showEditDialog(context, null);

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -26,31 +26,29 @@ class ListPage extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-
     final scrollController = useScrollController();
 
     useOnAppLifecycleStateChange((previous, current) async {
-
       /// バックグラウンドになったタイミングで、ScreenLockを呼び出す
       ///
       /// 最初はresumedのタイミングで呼び出そうとしたが、一瞬ListPageが表示されてしまうため、
       /// inactiveのタイミングで呼び出すこととしたもの
-      if(current == AppLifecycleState.inactive) {
+      if (current == AppLifecycleState.inactive) {
         // 全画面広告から復帰した際は表示しない
         // 全画面広告表示時にinactiveになるが、そのタイミングではパスコードロック画面を表示したくないため
-        if(ref.read(isShownInterstitialAdProvider)) {
+        if (ref.read(isShownInterstitialAdProvider)) {
           return;
         }
 
         // 初めて通知設定した際は、端末の通知設定ダイアログによりinactiveになるが、その際は表示しない
         // isShowScreenLockProviderにて使用
-        if(ref.read(isInitialSetNotificationProvider)) {
+        if (ref.read(isInitialSetNotificationProvider)) {
           return;
         }
         // 上記の全画面広告と端末の通知設定によるinactive時は処理を除外するコードは、
         // 当初「isShowScreenLockProvider」に記載していたが、inactive時にのみ必要な条件分岐のためこちらに記載
 
-        if(ref.read(isShowScreenLockProvider)) {
+        if (ref.read(isShowScreenLockProvider)) {
           await showScreenLock(context, ref);
         }
       }
@@ -61,7 +59,6 @@ class ListPage extends HookConsumerWidget {
       /// アプリをバックグラウンド→翌日にフォアグラウンドに復帰（resume）→アプリは再起動しない場合がある（端末依存）→日付が更新されずにハイライト箇所が正しくならない
       /// 上記の事象へ対応するもの
       if (current == AppLifecycleState.resumed) {
-
         final now = DateTime.now();
         final nowDate = DateTime(now.year, now.month, now.day);
         // バックグラウンド移行時の日と復帰時の日が一緒の場合は処理終了
@@ -73,55 +70,66 @@ class ListPage extends HookConsumerWidget {
           return DateTime(now.year, now.month, now.day);
         });
       }
-
-    });
-
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-
-      /// 月の後半になると、初期起動画面で該当日が表示されないことへの対応
-      ///
-      /// 当月の場合のみ、「SizedListTileの高さ*（当日の日数-5）」分だけスクロールする
-      /// -5としているのは、当日を一番上にするよりも当日の4日前まで見れた方が良いと考えたため
-      /// ほとんどの端末で15日程度は表示できると考えるため、当日が10日以下の場合はスクロールしない
-      if(ref.read(dateControllerProvider).isJumpToAroundToday()) {
-        final today = ref.read(todayProvider);
-        if (scrollController.hasClients) {
-          scrollController.jumpTo(Constant.sizedListTileHeight * (today.day - 5));
-        }
-      }
-
-      /// 所定条件をクリアしている場合、起動時に日記入力ダイアログを自動表示する
-      if(ref.read(isShowEditDialogOnLaunchProvider)) {
-        ref.read(isOpenedEditDialogProvider.notifier).state = true;
-        await _showEditDialog(context, null);
-        return;
-      }
-
-      /// 初回起動時に限り、アラーム設定を促すダイアログを表示する
-      ///それに加えて日記記入ダイアログを自動表示する
-      ///
-      /// ユーザー動作の順番的にSetNotificationDialog→EditDialog→ListPageの順で表示したいため、以下のような記述とした
-      if (ref.read(isShowSetNotificationDialogOnLaunchProvider)) {
-        ref.read(isOpenedSetNotificationDialogOnLaunchProvider.notifier).state = true;
-        await _showSetNotificationDialog(context);
-        if(context.mounted) {
-          await _showEditDialog(context, null);
-        }
-      }
-      //当初は、ForcedUpdateDialog及びUnderRepairDialogもここで表現していたが、
-      //これらは、Firestore上のtrue/falseで表示非表示を切り替えたく、Stackで対応することとした
-      //ここでも「trueになったら表示」はできるが、「falseになったら非表示」をするには別途変数が必要になりそうで、
-      //煩雑になると考え、Stackとしたもの。
     });
 
     useEffect(
       () {
-        // パスコードロック画面の表示
-        if(ref.read(isShowScreenLockProvider)) {
-          Future(() async {
+        Future(() async {
+
+          // パスコードロック画面の表示
+          if (ref.read(isShowScreenLockProvider)) {
             await showScreenLock(context, ref);
-          });
-        }
+          }
+
+          /// 0.5秒待機
+          ///
+          /// [scrollController.hasClients]と[ref.read(isShowEditDialogOnLaunchProvider]内の
+          /// 今日の日付の日記が記録済みかどうか？の判定に少し時間がかかるため、少し待ってから処理を行う
+          /// 待つ処理を挟まないと、jumpToの条件判定と、isShowEditDialogOnLaunchProviderの判定が適切に動作しない
+          await Future<void>.delayed(const Duration(milliseconds: 500));
+
+          if (!context.mounted) {
+            return;
+          }
+
+          /// 月の後半になると、初期起動画面で該当日が表示されないことへの対応
+          ///
+          /// 当月の場合のみ、「SizedListTileの高さ*（当日の日数-5）」分だけスクロールする
+          /// -5としているのは、当日を一番上にするよりも当日の4日前まで見れた方が良いと考えたため
+          /// ほとんどの端末で15日程度は表示できると考えるため、当日が10日以下の場合はスクロールしない
+          if (ref.read(dateControllerProvider).isJumpToAroundToday()) {
+            final today = ref.read(todayProvider);
+            if (scrollController.hasClients) {
+              scrollController
+                  .jumpTo(Constant.sizedListTileHeight * (today.day - 5));
+            }
+          }
+
+          /// 所定条件をクリアしている場合、起動時に日記入力ダイアログを自動表示する
+          if (ref.read(isShowEditDialogOnLaunchProvider)) {
+            ref.read(isOpenedEditDialogProvider.notifier).state = true;
+            await _showEditDialog(context, null);
+            return;
+          }
+
+          /// 初回起動時に限り、アラーム設定を促すダイアログを表示する
+          ///それに加えて日記記入ダイアログを自動表示する
+          ///
+          /// ユーザー動作の順番的にSetNotificationDialog→EditDialog→ListPageの順で表示したいため、以下のような記述とした
+          if (ref.read(isShowSetNotificationDialogOnLaunchProvider)) {
+            ref
+                .read(isOpenedSetNotificationDialogOnLaunchProvider.notifier)
+                .state = true;
+            await _showSetNotificationDialog(context);
+            if (context.mounted) {
+              await _showEditDialog(context, null);
+            }
+          }
+          //当初は、ForcedUpdateDialog及びUnderRepairDialogもここで表現していたが、
+          //これらは、Firestore上のtrue/falseで表示非表示を切り替えたく、Stackで対応することとした
+          //ここでも「trueになったら表示」はできるが、「falseになったら非表示」をするには別途変数が必要になりそうで、
+          //煩雑になると考え、Stackとしたもの。
+        });
         return null;
       },
       const [],
@@ -133,7 +141,7 @@ class ListPage extends HookConsumerWidget {
     final isPassCodeLocked = ref.watch(isOpenedScreenLockProvider);
     // パスコードロック画面を表示している間は何も表示しない
     // これをしないと一瞬日記画面が表示されてしまうため
-    if(isPassCodeLocked) {
+    if (isPassCodeLocked) {
       return const SizedBox();
     }
 
@@ -223,7 +231,8 @@ class ListPage extends HookConsumerWidget {
                           padding: const EdgeInsets.only(top: 4, bottom: 8),
                           child: ListView.separated(
                             controller: scrollController,
-                            separatorBuilder: (BuildContext context, int index) {
+                            separatorBuilder:
+                                (BuildContext context, int index) {
                               return const Divider(
                                 height: 0.5,
                               );
@@ -267,8 +276,9 @@ class ListPage extends HookConsumerWidget {
                                   diary?.content ?? '',
                                 ),
                                 onTap: () async {
-                                  ref.read(selectedDateProvider.notifier).state =
-                                      indexDate;
+                                  ref
+                                      .read(selectedDateProvider.notifier)
+                                      .state = indexDate;
                                   await _showEditDialog(context, diary);
                                 },
                                 onLongPress: diary == null
@@ -322,7 +332,8 @@ class ListPage extends HookConsumerWidget {
     required WidgetRef ref,
     required Diary diary,
   }) {
-    final diaryDateStr = '${diary.diaryDate.year}/${diary.diaryDate.month}/${diary.diaryDate.day}';
+    final diaryDateStr =
+        '${diary.diaryDate.year}/${diary.diaryDate.month}/${diary.diaryDate.day}';
     AwesomeDialog(
       //TODO ボタンカラー再検討
       context: context,

--- a/lib/list_page.dart
+++ b/lib/list_page.dart
@@ -83,16 +83,11 @@ class ListPage extends HookConsumerWidget {
       /// 当月の場合のみ、「SizedListTileの高さ*（当日の日数-5）」分だけスクロールする
       /// -5としているのは、当日を一番上にするよりも当日の4日前まで見れた方が良いと考えたため
       /// ほとんどの端末で15日程度は表示できると考えるため、当日が10日以下の場合はスクロールしない
-      final today = ref.read(dateControllerProvider).today;
-      final selectedMonth = ref.read(dateControllerProvider).selectedMonth;
-      if(today.month == selectedMonth.month) {
-        if (!scrollController.hasClients) {
-          return;
+      if(ref.read(dateControllerProvider).isJumpToToday()) {
+        final today = ref.read(todayProvider);
+        if (scrollController.hasClients) {
+          scrollController.jumpTo(Constant.sizedListTileHeight * (today.day - 5));
         }
-        if(today.day <= 10) {
-          return;
-        }
-        scrollController.jumpTo(Constant.sizedListTileHeight * (today.day - 5));
       }
 
       /// 所定条件をクリアしている場合、起動時に日記入力ダイアログを自動表示する


### PR DESCRIPTION
## 関連issue
close #92 

## やったこと
- 日記入力ダイアログの自動表示ロジックの修正
- 以下のシチュエーションでは本来自動表示されてはいけないが、自動表示されていた
  1. アプリを開いた日 = 5/9
  2. 5/9の日記は既に入力済み
  3. カレンダーを4月に移動
  4. カレンダーを5月に戻す　→　ここで既に5/9は入力済みなのにダイアログが表示されいた
- WidgetsBinding.instance.addPostFrameCallbackの使用をやめて、useEffect内で処理する形に修正
- それに伴う修正


## 関連画像
<img src="" width=300>
