### PR TITLE
Background fetchをONにすべきところ、BackgroundProcessingがONになっていたので修正

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,7 +34,7 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>processing</string>
+		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
## 関連issue
close 

## やったこと
- AppStoreにアップロードする際、以下のエラーが発生したため対応
- https://zenn.dev/yamatatsu10969/scraps/d61005bc83159f
- 以下記事のBackground fetchをONにすべきところ、BackgroundProcessingがONにしてしまっていたため修正
- https://zenn.dev/mamushi/articles/flutter_push_notification

## 関連画像
<img src="" width=300>
