### PR TITLE
build.gradleのバージョン変更

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.0'
         // START: FlutterFire Configuration
         classpath 'com.google.gms:google-services:4.3.10'
         // END: FlutterFire Configuration


### PR DESCRIPTION
## 関連issue
close 

## やったこと
- build.gradleのバージョン変更
- 別途新規でFlutterプロジェクトを作成し、そのbuild.graldeに合わせて修正したところエラーがなくなった
- 以下記事と同じようなエラーが発生したため（kotlinバージョンの不整合？）
- https://stackoverflow.com/questions/72927114/the-binary-version-of-its-metadata-is-1-7-1-expected-version-is-1-5-1

## 関連画像
<img src="" width=300>
