### PR TITLE
#113 fix delete account

### DIFF
--- a/lib/feature/auth/auth_repository.dart
+++ b/lib/feature/auth/auth_repository.dart
@@ -59,8 +59,7 @@ class AuthRepository {
     if(user == null) {
       return;
     }
-    // Authアカウントの削除
-    await user.delete();
+
     final uid = user.uid;
     final userRef = firestore.collection('users').doc(uid);
 
@@ -90,6 +89,13 @@ class AuthRepository {
 
     // users情報の削除
     await userRef.delete();
+
+    // Authアカウントの削除
+    // データ削除よりも前にアカウント削除してしまうと、
+    // セキュリティルールの「isUserAuthenticated(userId)」で引っかかりエラーが発生する
+    // そのため、アカウント削除は最後に実行する
+    await user.delete();
+
   }
 
 


### PR DESCRIPTION
## 関連issue
close #113 

## やったこと
- Prod環境のみ、退会処理がうまく動作していなかったため対応
- Authのアカウントを削除した後に、Firestoreの削除を実行しており、Firestoreのセキュリティルールに引っかかっていたため
- Authのアカウント削除をFirestoreのデータ削除後に変更
- 合わせて、退会処理時のエラーハンドリングを追加

## 関連画像
<img src="" width=300>
