### PR TITLE
#124 fix notification settings prompt timing

### DIFF
--- a/lib/feature/diary/complete_dialog_content.dart
+++ b/lib/feature/diary/complete_dialog_content.dart
@@ -47,7 +47,7 @@ class CompleteDialogContent extends HookConsumerWidget {
                   onPressed: () async {
                     Navigator.pop(context);
                     Navigator.pop(context);
-                    // 更新の場合全画面広告は表示しない
+                    // 更新の場合は処理終了
                     if (inputDiaryType == InputDiaryType.update) {
                       return;
                     }

--- a/lib/feature/diary/complete_dialog_content.dart
+++ b/lib/feature/diary/complete_dialog_content.dart
@@ -6,6 +6,7 @@ import 'package:sizer/sizer.dart';
 import '../../component/stadium_border_button.dart';
 import '../../constant/enum.dart';
 import '../admob/ad_controller.dart';
+import '../local_notification/local_notification_controller.dart';
 import 'diary_service.dart';
 
 class CompleteDialogContent extends HookConsumerWidget {
@@ -50,6 +51,15 @@ class CompleteDialogContent extends HookConsumerWidget {
                     // 更新の場合は処理終了
                     if (inputDiaryType == InputDiaryType.update) {
                       return;
+                    }
+                    // 初めて日記登録した直後にリマインダー設定を促す
+                    if (data == 1) {
+                      return ref
+                          .read(localNotificationControllerProvider)
+                          .showSetNotificationDialog(
+                            context: context,
+                            trigger: NotificationDialogTrigger.onFirstLaunch,
+                          );
                     }
                     // 9日目 or 51日目の記録の場合、アプリのレビューを依頼する(全画面広告は表示しない)
                     if (data == 9 || data == 51) {

--- a/lib/feature/diary/diary_controller.dart
+++ b/lib/feature/diary/diary_controller.dart
@@ -123,6 +123,8 @@ class DiaryController {
     await AwesomeDialog(
       context: context,
       dialogType: DialogType.success,
+      dismissOnTouchOutside: false,
+      dismissOnBackKeyPress: false,
       body: CompleteDialogContent(inputDiaryType: inputDiaryType),
     ).show();
   }

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -18,10 +18,10 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final notificationTime = ref.watch(localNotificationTimeFutureProvider);
+    final savedNotificationTime = ref.watch(localNotificationTimeFutureProvider);
     final localNotificationController =
         ref.watch(localNotificationControllerProvider);
-    return notificationTime.when(
+    return savedNotificationTime.when(
       loading: () => const Scaffold(
         body: Center(
           child: CircularProgressIndicator(),
@@ -51,7 +51,7 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
           ),
         );
       },
-      data: (data) => AlertDialog(
+      data: (savedNotificationTime) => AlertDialog(
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(
             Radius.circular(20),
@@ -94,14 +94,14 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
                 '設定された時間に毎日通知！\n継続をサポートします',
                 textAlign: TextAlign.center,
               ),
-              data == null
+              savedNotificationTime == null
                   ? Padding(
                       padding: const EdgeInsets.only(top: 16),
                       child: StadiumBorderButton(
                         onPressed: () async {
                           await localNotificationController.setNotification(
                             context: context,
-                            savedNotificationTime: data,
+                            savedNotificationTime: null,
                           );
                         },
                         title: Padding(
@@ -117,18 +117,18 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
                       onPressed: () async {
                         await localNotificationController.setNotification(
                           context: context,
-                          savedNotificationTime: data,
+                          savedNotificationTime: savedNotificationTime,
                         );
                       },
                       child: Text(
-                        data.to24hours(),
+                        savedNotificationTime.to24hours(),
                         style: TextStyle(
                           fontSize: 48.sp,
                         ),
                       ),
                     ),
               Visibility(
-                visible: data != null,
+                visible: savedNotificationTime != null,
                 child: Column(
                   children: [
                     TextButton(

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -65,8 +65,7 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
           ),
           child: ColoredBox(
             // color: Theme.of(context).primaryColor,
-            // color: Colors.black,
-            color: const Color(0xFF000000),
+            color: Colors.black,
             child: Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               child: FittedBox(

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -52,6 +52,7 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
         );
       },
       data: (savedNotificationTime) => AlertDialog(
+        //TODO Theme設定でまとめた方が良さそう
         shape: const RoundedRectangleBorder(
           borderRadius: BorderRadius.all(
             Radius.circular(20),

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -57,66 +57,97 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
             Radius.circular(20),
           ),
         ),
-        title: Text(
-          '設定時間に毎日通知して\n継続をサポートします',
-          style: TextStyle(fontSize: 14.sp),
-          textAlign: TextAlign.center,
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            data == null
-                ? StadiumBorderButton(
-                    onPressed: () async {
-                      await localNotificationController.setNotification(
-                        context: context,
-                        savedNotificationTime: data,
-                      );
-                    },
-                    title: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 8),
-                      child: Text(
-                        '通知時間を設定する',
-                        style: TextStyle(fontSize: 14.sp),
-                      ),
-                    ),
-                  )
-                : TextButton(
-                    onPressed: () async {
-                      await localNotificationController.setNotification(
-                        context: context,
-                        savedNotificationTime: data,
-                      );
-                    },
-                    child: Text(
-                      data.to24hours(),
-                      style: TextStyle(
-                        fontSize: 48.sp,
-                      ),
-                    ),
+        titlePadding: EdgeInsets.zero,
+        title: ClipRRect(
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+          child: ColoredBox(
+            // color: Theme.of(context).primaryColor,
+            // color: Colors.black,
+            color: const Color(0xFF000000),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  trigger == NotificationDialogTrigger.onFirstLaunch
+                      ? 'リマインダーを設定しましょう！'
+                      : 'リマインダー設定',
+                  style: TextStyle(
+                    fontSize: 16.sp,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
                   ),
-            Visibility(
-              visible: data != null,
-              child: Column(
-                children: [
-                  TextButton(
-                    onPressed: () async {
-                      await localNotificationController.deleteNotification();
-                    },
-                    child: const Text('通知設定をリセットする'),
-                  ),
-                ],
+                  textAlign: TextAlign.center,
+                ),
               ),
             ),
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-              },
-              child: trigger == NotificationDialogTrigger.onFirstLaunch
-                  ? const Text('あとで設定する')
-                  : const Text('閉じる'),
-            ),
-          ],
+          ),
+        ),
+        content: Padding(
+          padding: const EdgeInsets.only(top: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                '設定された時間に毎日通知！\n継続をサポートします',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              data == null
+                  ? StadiumBorderButton(
+                      onPressed: () async {
+                        await localNotificationController.setNotification(
+                          context: context,
+                          savedNotificationTime: data,
+                        );
+                      },
+                      title: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: Text(
+                          '通知時間を設定する',
+                          style: TextStyle(fontSize: 14.sp),
+                        ),
+                      ),
+                    )
+                  : TextButton(
+                      onPressed: () async {
+                        await localNotificationController.setNotification(
+                          context: context,
+                          savedNotificationTime: data,
+                        );
+                      },
+                      child: Text(
+                        data.to24hours(),
+                        style: TextStyle(
+                          fontSize: 48.sp,
+                        ),
+                      ),
+                    ),
+              Visibility(
+                visible: data != null,
+                child: TextButton(
+                  onPressed: () async {
+                    await localNotificationController.deleteNotification();
+                  },
+                  child: const Text('通知設定をリセットする'),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: trigger == NotificationDialogTrigger.onFirstLaunch
+                      ? const Text('あとで設定する')
+                      : const Text('閉じる'),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -64,10 +64,9 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
             topRight: Radius.circular(20),
           ),
           child: ColoredBox(
-            // color: Theme.of(context).primaryColor,
             color: Colors.black,
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+              padding: const EdgeInsets.all(16),
               child: FittedBox(
                 fit: BoxFit.scaleDown,
                 child: Text(

--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -95,20 +95,22 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
                 '設定された時間に毎日通知！\n継続をサポートします',
                 textAlign: TextAlign.center,
               ),
-              const SizedBox(height: 16),
               data == null
-                  ? StadiumBorderButton(
-                      onPressed: () async {
-                        await localNotificationController.setNotification(
-                          context: context,
-                          savedNotificationTime: data,
-                        );
-                      },
-                      title: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        child: Text(
-                          '通知時間を設定する',
-                          style: TextStyle(fontSize: 14.sp),
+                  ? Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: StadiumBorderButton(
+                        onPressed: () async {
+                          await localNotificationController.setNotification(
+                            context: context,
+                            savedNotificationTime: data,
+                          );
+                        },
+                        title: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          child: Text(
+                            '通知時間を設定する',
+                            style: TextStyle(fontSize: 14.sp),
+                          ),
                         ),
                       ),
                     )
@@ -128,22 +130,27 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
                     ),
               Visibility(
                 visible: data != null,
-                child: TextButton(
-                  onPressed: () async {
-                    await localNotificationController.deleteNotification();
-                  },
-                  child: const Text('通知設定をリセットする'),
+                child: Column(
+                  children: [
+                    TextButton(
+                      onPressed: () async {
+                        await localNotificationController.deleteNotification();
+                      },
+                      child: const Text('通知設定をリセットする'),
+                    ),
+                  ],
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: TextButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                  child: trigger == NotificationDialogTrigger.onFirstLaunch
-                      ? const Text('あとで設定する')
-                      : const Text('閉じる'),
+              Visibility(
+                visible: trigger == NotificationDialogTrigger.userAction,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: TextButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                    child: const Text('閉じる'),
+                  ),
                 ),
               ),
             ],

--- a/lib/feature/setting/terms_of_service/terms_of_service_confirmation_page.dart
+++ b/lib/feature/setting/terms_of_service/terms_of_service_confirmation_page.dart
@@ -47,20 +47,6 @@ class TermsOfServiceConfirmationPage extends HookConsumerWidget {
                     .completedFirstLaunch();
                 // 広告トラッキング許可ダイアログ表示
                 await ref.read(adControllerProvider).requestATT();
-                if (!context.mounted) {
-                  return;
-                }
-                await ref
-                    .read(localNotificationControllerProvider)
-                    .showSetNotificationDialog(
-                      context: context,
-                      trigger: NotificationDialogTrigger.onFirstLaunch,
-                    );
-                // 通知設定完了後（通知設定ダイアログが閉じたら）、AuthPageへ遷移する
-                // 当初は通知設定ダイアログ側でAuthPageへの遷移を記述していたが、それだとローカル通知時間が正しく反映されない
-                if (!context.mounted) {
-                  return;
-                }
                 await routingController.goAuthPage();
               },
             ),


### PR DESCRIPTION
## 関連issue
close #124 

## やったこと
- リマインダー設定ダイアログを表示するタイミングの変更
- 変更前：「利用規約に同意する」押下後
- 変更後：1つ目の日記登録後
- 変更理由：離脱率を減らすため、ユーザーにアプリを使ってもらった後の方が望ましいと考えたため

## 関連画像
### 1つ目の日記登録後
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-22 at 16 20 05](https://github.com/haterain0203/limited_characters_diary/assets/58384546/e8785f50-3896-4f04-a0e8-cfe584824bae)

### Homeの左上 or 設定画面からの呼び出し時
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-22 at 16 20 40](https://github.com/haterain0203/limited_characters_diary/assets/58384546/ee4864d5-e81e-4ed2-bc57-24d6903fcfab)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-22 at 16 20 37](https://github.com/haterain0203/limited_characters_diary/assets/58384546/a0e82ecf-c202-4560-b4e1-789b2ce7c4fc)