### PR TITLE
#150 リマインダー設定アイコンの変更と「通知」を一部「リマインダー」に変更

### DIFF
--- a/lib/feature/local_notification/local_notification_setting_dialog.dart
+++ b/lib/feature/local_notification/local_notification_setting_dialog.dart
@@ -18,7 +18,8 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final savedNotificationTime = ref.watch(localNotificationTimeFutureProvider);
+    final savedNotificationTime =
+        ref.watch(localNotificationTimeFutureProvider);
     final localNotificationController =
         ref.watch(localNotificationControllerProvider);
     return savedNotificationTime.when(
@@ -135,7 +136,7 @@ class LocalNotificationSettingDialog extends HookConsumerWidget {
                       onPressed: () async {
                         await localNotificationController.deleteNotification();
                       },
-                      child: const Text('通知設定をリセットする'),
+                      child: const Text('リセットする'),
                     ),
                   ],
                 ),

--- a/lib/feature/setting/setting_page.dart
+++ b/lib/feature/setting/setting_page.dart
@@ -49,7 +49,7 @@ class SettingPage extends StatelessWidget {
                       color: Theme.of(context).primaryColor,
                     ),
                     title: const Text(
-                      '通知設定',
+                      'リマインダー設定',
                       style: textStyle,
                     ),
                     onPressed: (BuildContext context) {

--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -35,7 +35,7 @@ class HomePage extends HookConsumerWidget {
                         trigger: NotificationDialogTrigger.userAction,
                       );
                 },
-                icon: const Icon(Icons.add_alert),
+                icon: const Icon(Icons.notification_add),
               ),
               title: Row(
                 mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## 関連issue
close #150 

## やったこと
- リマインダー設定アイコンの変更
- 「通知」を一部「リマインダー」に変更

## 関連画像
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-25 at 06 43 17](https://github.com/haterain0203/limited_characters_diary/assets/58384546/1a588294-016a-4860-ae4c-ef5461d2f681)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-25 at 06 43 20](https://github.com/haterain0203/limited_characters_diary/assets/58384546/96d4af59-3db7-4c8b-966e-e77ee6048612)
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-06-25 at 06 43 26](https://github.com/haterain0203/limited_characters_diary/assets/58384546/282ae79c-f8bd-4223-9293-b42814cf7e33)