### PR TITLE
ソーシャル認証ダイアログ表示時にパスコードロック画面が表示されないよう制御

### DIFF
--- a/lib/feature/auth/auth_controller.dart
+++ b/lib/feature/auth/auth_controller.dart
@@ -15,12 +15,15 @@ import '../../constant/enum.dart';
 import '../exception/exception.dart';
 import 'confirm_delete_all_data_dialog.dart';
 
-/// ソーシャル認証用のダイアログを表示したか否か
+/// ソーシャル認証用のダイアログを表示したか否かを管理する。
 ///
 /// ソーシャル認証（連携・連携解除）時に、ソーシャル認証のダイアログが表示されるが、
 /// その際、アプリがinactiveになりパスコードロック画面が表示されてしまうため、
 /// ソーシャル認証用のダイアログ表示にはパスコードロック画面を表示しないようにするために使用するもの。
 final isShownSocialAuthDialog = StateProvider((ref) => false);
+
+/// ユーザーデータ削除時には日記入力ダイアログを表示しないように制御するため
+final isUserDeletedProvider = StateProvider((ref) => false);
 
 final authControllerProvider = Provider.autoDispose(
   (ref) => AuthController(
@@ -320,6 +323,3 @@ class AuthController {
     }
   }
 }
-
-/// ユーザーデータ削除時には日記入力ダイアログを表示しないように制御するため
-final isUserDeletedProvider = StateProvider((ref) => false);

--- a/lib/feature/auth/auth_controller.dart
+++ b/lib/feature/auth/auth_controller.dart
@@ -153,6 +153,7 @@ class AuthController {
       loadingNotifier.startLoading();
 
       // ソーシャル認証ダイアログ表示時にパスコードロック画面が表示されないよう制御
+      // TODO: 直書きではなく、Notifierなどを活用して関数化すべき（他の箇所も同様）
       isShownSocialAuthDialog.state = true;
 
       await service.deleteUser();

--- a/lib/feature/pass_code/pass_code_controller.dart
+++ b/lib/feature/pass_code/pass_code_controller.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screen_lock/flutter_screen_lock.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:limited_characters_diary/constant/constant_log_event_name.dart';
+import 'package:limited_characters_diary/feature/auth/auth_controller.dart';
 import 'package:limited_characters_diary/feature/pass_code/pass_code_service.dart';
 
 import '../admob/ad_controller.dart';
@@ -22,6 +23,7 @@ final passCodeControllerProvider = Provider(
       isInitialSetNotificationNotifier:
           ref.read(isInitialSetNotificationProvider.notifier),
       analyticsController: ref.watch(analyticsContollerProvider),
+      isShownSocialAuthDialog: ref.watch(isShownSocialAuthDialog),
     );
   },
 );
@@ -36,6 +38,7 @@ class PassCodeController {
     required this.isInitialSetNotification,
     required this.isInitialSetNotificationNotifier,
     required this.analyticsController,
+    required this.isShownSocialAuthDialog,
   });
 
   final PassCodeService service;
@@ -46,6 +49,7 @@ class PassCodeController {
   final bool isInitialSetNotification;
   final StateController<bool> isInitialSetNotificationNotifier;
   final AnalyticsController analyticsController;
+  final bool isShownSocialAuthDialog;
 
   /// 設定画面におけるパスコード設定のトグル切り替え
   ///
@@ -142,6 +146,12 @@ class PassCodeController {
     if (isInitialSetNotification) {
       // falseに戻さないと、初めて通知設定した後にinactiveにした際にロック画面が表示されない
       isInitialSetNotificationNotifier.state = false;
+      return false;
+    }
+
+    // ソーシャル認証ダイアログが表示されている場合は処理終了（パスコードロックを表示しない）
+    // ソーシャル認証ダイアログ表示時にinactiveになるが、そのタイミングではパスコードロック画面を表示したくないため
+    if (isShownSocialAuthDialog) {
       return false;
     }
 


### PR DESCRIPTION
## 関連issue
close #169 

## やったこと
- ソーシャル認証ダイアログ表示時にパスコードロック画面が表示されないよう制御

## 関連画像
<img src="" width=300>
