### PR TITLE
Feature/fix crashlytics

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\" --flutter-project \"$PROJECT_DIR/firebase_app_id_file.json\" ";
+			shellScript = "\"$PODS_ROOT/FirebaseCrashlytics/upload-symbols\" -gsp \"${PROJECT_DIR}/GoogleService-Info.plist\" -p ios \"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}\"\n\n";
 		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -305,7 +305,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build\n";
 		};
 		A2C79F33D63BF6D4E265C830 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -85,6 +85,7 @@ Future<void> main() async {
   runApp(
     Phoenix(
       child: DevicePreview(
+        enabled: !kReleaseMode,
         builder: (_) => ProviderScope(
           overrides: [
             localNotificationServiceProvider

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.1.0+24
+version: 1.1.0+25
 environment:
   sdk: '>=3.0.0 <4.0.0'
 


### PR DESCRIPTION
## 関連issue
close 

## やったこと
- [こちら等](https://halzoblog.com/error-bug-diary/20230423-2/)と同じく、prod/devともにdsymsのアラート発生
- crashlytics 追加時に自動追加された xcode -> BuildPhases -> [firebase_crashlytics] Crashlytics Upload Symbolsを、dev/prodで切り替えられるよう以下の通り修正したところ解消した。
- 修正前
```
"$PODS_ROOT/FirebaseCrashlytics/upload-symbols" --flutter-project "$PROJECT_DIR/firebase_app_id_file.json" 
```
- 修正後
```
"$PODS_ROOT/FirebaseCrashlytics/upload-symbols" -gsp "${PROJECT_DIR}/GoogleService-Info.plist" -p ios "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}"

```


## 関連画像
<img src="" width=300>
