### PR TITLE
Feature/#189 fix local notifications for android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,7 +43,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -103,7 +103,7 @@ flutter {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.2.2'
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     -->
     <!-- https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/example/android/app/src/main/AndroidManifest.xml -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
         android:label="@string/app_name"
@@ -41,5 +42,14 @@
        <meta-data
            android:name="com.google.android.gms.ads.APPLICATION_ID"
            android:value="ca-app-pub-3940256099942544~3347511713"/>
+       <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+       <receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+           <intent-filter>
+               <action android:name="android.intent.action.BOOT_COMPLETED"/>
+               <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+               <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+               <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+           </intent-filter>
+       </receiver>
     </application>
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         // START: FlutterFire Configuration
         classpath 'com.google.gms:google-services:4.3.10'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.8.1'

--- a/lib/feature/local_notification/local_notification_service.dart
+++ b/lib/feature/local_notification/local_notification_service.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:limited_characters_diary/feature/local_notification/local_notification_repository.dart';
 import 'package:timezone/data/latest_all.dart' as tz;
@@ -51,7 +51,7 @@ class LocalNotificationService {
 
   Future<void> _setTimeZone() async {
     tz.initializeTimeZones();
-    final timeZoneName = await FlutterNativeTimezone.getLocalTimezone();
+    final timeZoneName = await FlutterTimezone.getLocalTimezone();
     tz.setLocalLocation(tz.getLocation(timeZoneName));
   }
 

--- a/lib/feature/local_notification/local_notification_service.dart
+++ b/lib/feature/local_notification/local_notification_service.dart
@@ -79,7 +79,7 @@ class LocalNotificationService {
           channelDescription: 'your channel description',
         ),
       ),
-      androidAllowWhileIdle: true,
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
       uiLocalNotificationDateInterpretation:
           UILocalNotificationDateInterpretation.absoluteTime,
       //同じ時間に毎日通知

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -498,26 +498,26 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "293995f94e120c8afce768981bd1fa9c5d6de67c547568e3b42ae2defdcbb4a0"
+      sha256: "892ada16046d641263f30c72e7432397088810a84f34479f6677494802a2b535"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "16.3.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: ccb08b93703aeedb58856e5637450bf3ffec899adb66dc325630b68994734b89
+      sha256: "33f741ef47b5f63cc7f78fe75eeeac7e19f171ff3c3df054d84c1e38bedb6a03"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0+1"
+    version: "4.0.0+1"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "5ec1feac5f7f7d9266759488bc5f76416152baba9aa1b26fe572246caa00d1ab"
+      sha256: "7cf643d6d5022f3baed0be777b0662cce5919c0a7b86e700299f22dc4ae660ef"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "7.0.0+1"
   flutter_localizations:
     dependency: transitive
     description: flutter

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -531,14 +531,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.19"
-  flutter_native_timezone:
-    dependency: "direct main"
-    description:
-      name: flutter_native_timezone
-      sha256: ed7bfb982f036243de1c068e269182a877100c994f05143c8b26a325e28c1b02
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
   flutter_phoenix:
     dependency: "direct main"
     description:
@@ -576,6 +568,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "06b35132c98fa188db3c4b654b7e1af7ccd01dfe12a004d58be423357605fb24"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.8"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   flutter_hooks: ^0.18.6
   flutter_launcher_icons: ^0.13.0
-  flutter_local_notifications: ^13.0.0
+  flutter_local_notifications: ^16.3.0
   flutter_native_timezone: ^2.0.0
   flutter_phoenix: ^1.1.1
   flutter_screen_lock: ^9.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,10 +27,10 @@ dependencies:
   flutter_hooks: ^0.18.6
   flutter_launcher_icons: ^0.13.0
   flutter_local_notifications: ^16.3.0
-  flutter_native_timezone: ^2.0.0
   flutter_phoenix: ^1.1.1
   flutter_screen_lock: ^9.0.1
   flutter_slidable: ^3.0.0
+  flutter_timezone: ^1.0.8
   font_awesome_flutter: ^10.4.0
   freezed_annotation: ^2.2.0
   google_mobile_ads: ^2.4.0


### PR DESCRIPTION
## 関連issue
- #189 

## やったこと（概要）
- flutter_local_notifications を更新
- それに伴う各種設定の修正（ compileSDK 34 への更新含む）
- それに伴い発生したビルドエラーの対応として、flutter_native_time_zone を flutter_timezone に変更

## やったこと（詳細）
- 2024-01-13 flutter_local_notifications: ^16.3.0 0e78be7 
- 2024-01-13 パッケージのREADMEに沿って修正 e14926c
- 2024-01-13 READMEに沿って `android/build.gradle` を更新 ce16022
- 2024-05-06 以下の公式ドキュメントに沿って compileSDK を 34 に 
https://pub.dev/packages/flutter_local_notifications#-android-setup 89b4af0 
- 2024-05-06 以下の公式に準拠した Manifest.xml の修正 
https://pub.dev/packages/flutter_local_notifications#-android-setup a83c318
- 2024-05-06 androidScheduleMode に AndroidScheduleMode.inexactAllowWhileIdle を設定 e16044a
- 2024-05-06 flutter_native_time_zone を flutter_timezone に変更 2481ac5

## 関連画像
<img src="" width=300>
