### PR TITLE
firestore の セキュリティエラー時の画面表示方法修正（UnderRepairDialog / ForcedUpdateDialog）

### DIFF
--- a/lib/component/error_page.dart
+++ b/lib/component/error_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:limited_characters_diary/constant/constant_string.dart';
+
+import '../feature/routing/routing_controller.dart';
+import '../feature/setting/setting_controller.dart';
+
+class ErrorPage extends HookConsumerWidget {
+  const ErrorPage({
+    required this.error,
+    required this.stackTrace,
+    super.key,
+  });
+
+  final Object error;
+  final StackTrace stackTrace;
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('エラー'),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              SelectableText(
+                'エラーが発生しました。\n\n'
+                'お手数をおかけしますが、\n'
+                '時間を空けてアプリを再起動してください。\n\n'
+                '問題が解決しない場合は画面最下部の「問い合わせ」ボタンからお問合せをお願いします。\n\n'
+                '＜エラー内容＞\n'
+                '$error\n\n'
+                '＜StackTrace＞\n'
+                '$stackTrace',
+              ),
+              const SizedBox(height: 16),
+              FilledButton(
+                onPressed: () async {
+                  final contactUsUrl = await ref
+                      .read(settingControllerProvider)
+                      .createContactUsUrl();
+                  await ref
+                      .read(routingControllerProvider)
+                      .goContactUsOnWebView(
+                        url: contactUsUrl,
+                      );
+                },
+                child: const Text(ConstantString.contactUsStr),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/feature/update_info/forced_update_dialog.dart
+++ b/lib/feature/update_info/forced_update_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:limited_characters_diary/component/error_page.dart';
 import 'package:limited_characters_diary/feature/update_info/update_info_service.dart';
 import 'package:sizer/sizer.dart';
 
@@ -16,46 +17,52 @@ class ForcedUpdateDialog extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final shouldForceUpdate = ref.watch(shouldForceUpdateProvider);
 
-    // このダイアログは、緊急時以外ユーザーに見せないもの
-    // loadingおよびエラーハンドリングは不要と考え、.whenは使っていない
-    if (shouldForceUpdate.hasError ||
-        shouldForceUpdate.value == null ||
-        !shouldForceUpdate.value!) {
-      return const SizedBox.shrink();
-    }
-
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        ColoredBox(
-          color: Colors.grey.withOpacity(0.65),
-        ),
-        AlertDialog(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(
-              Radius.circular(20),
+    return shouldForceUpdate.when(
+      error: (e, s) {
+        return ErrorPage(
+          error: e,
+          stackTrace: s,
+        );
+      },
+      loading: () => const SizedBox.shrink(),
+      data: (shouldForceUpdate) {
+        if (!shouldForceUpdate) {
+          return const SizedBox.shrink();
+        }
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            ColoredBox(
+              color: Colors.grey.withOpacity(0.65),
             ),
-          ),
-          title: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: Text(
-              '最新版がリリースされています。\nアップデートをお願いします。',
-              style: TextStyle(
-                fontSize: 13.sp,
+            AlertDialog(
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(
+                  Radius.circular(20),
+                ),
+              ),
+              title: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Text(
+                  '最新版がリリースされています。\nアップデートをお願いします。',
+                  style: TextStyle(
+                    fontSize: 13.sp,
+                  ),
+                ),
+              ),
+              content: StadiumBorderButton(
+                onPressed: () async {
+                  final url = Platform.isAndroid
+                      ? ConstantString.playStoreUrl
+                      : ConstantString.appStoreUrl;
+                  await linkToAppOrWeb(url);
+                },
+                title: const Text('アプリストアへ'),
               ),
             ),
-          ),
-          content: StadiumBorderButton(
-            onPressed: () async {
-              final url = Platform.isAndroid
-                  ? ConstantString.playStoreUrl
-                  : ConstantString.appStoreUrl;
-              await linkToAppOrWeb(url);
-            },
-            title: const Text('アプリストアへ'),
-          ),
-        ),
-      ],
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/feature/update_info/forced_update_dialog.dart
+++ b/lib/feature/update_info/forced_update_dialog.dart
@@ -18,7 +18,9 @@ class ForcedUpdateDialog extends HookConsumerWidget {
 
     // このダイアログは、緊急時以外ユーザーに見せないもの
     // loadingおよびエラーハンドリングは不要と考え、.whenは使っていない
-    if (shouldForceUpdate.value == null || !shouldForceUpdate.value!) {
+    if (shouldForceUpdate.hasError ||
+        shouldForceUpdate.value == null ||
+        !shouldForceUpdate.value!) {
       return const SizedBox.shrink();
     }
 

--- a/lib/feature/update_info/under_repair_dialog.dart
+++ b/lib/feature/update_info/under_repair_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:limited_characters_diary/component/error_page.dart';
 import 'package:limited_characters_diary/feature/update_info/update_info_service.dart';
 import 'package:sizer/sizer.dart';
 
@@ -11,37 +12,41 @@ class UnderRepairDialog extends HookConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final updateInfo = ref.watch(updateInfoProvider);
 
-    // このダイアログは、緊急時以外ユーザーに見せないもの
-    // loadingおよびエラーハンドリングは不要と考え、.whenは使っていない
-    if (updateInfo.hasError ||
-        updateInfo.value == null ||
-        !updateInfo.value!.isUnderRepair) {
-      return const SizedBox.shrink();
-    }
+    return updateInfo.when(
+      error: (e, s) {
+        return ErrorPage(error: e, stackTrace: s);
+      },
+      loading: () => const SizedBox.shrink(),
+      data: (updateInfo) {
+        if (!updateInfo.isUnderRepair) {
+          return const SizedBox.shrink();
+        }
 
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        ColoredBox(
-          color: Colors.grey.withOpacity(0.65),
-        ),
-        AlertDialog(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(
-              Radius.circular(20),
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            ColoredBox(
+              color: Colors.grey.withOpacity(0.65),
             ),
-          ),
-          title: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: Text(
-              updateInfo.value!.underRepairComment,
-              style: TextStyle(
-                fontSize: 13.sp,
+            AlertDialog(
+              shape: const RoundedRectangleBorder(
+                borderRadius: BorderRadius.all(
+                  Radius.circular(20),
+                ),
+              ),
+              title: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Text(
+                  updateInfo.underRepairComment,
+                  style: TextStyle(
+                    fontSize: 13.sp,
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
-      ],
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/feature/update_info/under_repair_dialog.dart
+++ b/lib/feature/update_info/under_repair_dialog.dart
@@ -13,7 +13,9 @@ class UnderRepairDialog extends HookConsumerWidget {
 
     // このダイアログは、緊急時以外ユーザーに見せないもの
     // loadingおよびエラーハンドリングは不要と考え、.whenは使っていない
-    if (updateInfo.value == null || !updateInfo.value!.isUnderRepair) {
+    if (updateInfo.hasError ||
+        updateInfo.value == null ||
+        !updateInfo.value!.isUnderRepair) {
       return const SizedBox.shrink();
     }
 


### PR DESCRIPTION
## 関連issue
close #197 

## やったこと
- UnderRepairDialog / ForcedUpdateDialog のエラーハンドリング追加
- エラー時には今回追加した ErrorPage を表示する
## 関連画像
<img src="" width=300>
